### PR TITLE
Documentation, delete_callback, optimizations and sh1ft-at-github change for off

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ on any links or buttons that have the 'delete' class on them.
 ```
 
 ```html
-<a href="server.php" class="delete" data_type="post">Delete</a>
+<a href="server.php" class="delete" data-type="post">Delete</a>
 ```
 
 Initialise the plugin either in <script></script> tags on the html page or in an external .js script. 
@@ -41,7 +41,7 @@ $( document ).ready( function( )
 } );
 ```
 
-Notice the 'data_type' attribute on the link. The plugin will use this attribute if set to show a custom delete message. For example,
+Notice the 'data-type' attribute on the link. The plugin will use this attribute if set to show a custom delete message. For example,
 
 Heading:    'Delete Post'
 
@@ -93,12 +93,18 @@ Used if heading & message are not provided
 Will fire if responding to a button click that has no href attribute.
 
 Use this callback to do any deletions from a button click.
+Parameters:
+* data (data.originalObject contains the originally clicked object)
 
 ### delete_callback
 Will fire when the delete button is clicked and a handler is provided.
+Parameters:
+* data (data.originalObject contains the originally clicked object)
 
 ### cancel_callback
 Will fire when the cancel button is clicked and a handler is provided.
+Parameters:
+* data (data.originalObject contains the originally clicked object)
 
 
 ## License

--- a/bootstrap-confirm-delete.js
+++ b/bootstrap-confirm-delete.js
@@ -45,34 +45,41 @@
             $( '#bootstrap-confirm-dialog-text' ).html( plugin.settings.message );
             $( '#bootstrap-confirm-dialog' ).modal( 'toggle' );
 
+            var deleteBtn = $( 'a#bootstrap-confirm-dialog-delete-btn' );
+            var cancelBtn = $( 'a#bootstrap-confirm-dialog-cancel-delete-btn' );
+            var hasCallback = false;
             if ( null !== plugin.settings.callback )
             {
-                $( '#bootstrap-confirm-dialog-delete-btn' ).attr( 'data-dismiss', 'modal' );
-
                 if ( $.isFunction( plugin.settings.callback ) )
                 {
-                    var deleteBtn = $( 'a#bootstrap-confirm-dialog-delete-btn' );
-
-                    deleteBtn.off().on( 'click', { originalObject: $( this ) }, plugin.settings.callback );
-
-                    if ( null !== plugin.settings.delete_callback )
-                    {
-                        deleteBtn.off().on( 'click', { originalObject: $( this ) }, plugin.settings.delete_callback );
-                    }
+                    deleteBtn.attr( 'data-dismiss', 'modal' ).off('.bs-confirm-delete').on( 'click.bs-confirm-delete', { originalObject: $( this ) }, plugin.settings.callback );
+                    hasCallback = true;
                 }
                 else
                 {
                     console.log( plugin.settings.callback + ' is not a valid callback' );
                 }
             }
-            else if ( '' !== event.currentTarget.href )
+            if ( null !== plugin.settings.delete_callback )
             {
-                $( 'a#bootstrap-confirm-dialog-delete-btn' ).attr( 'href', event.currentTarget.href );
+                if ( $.isFunction( plugin.settings.delete_callback ) )
+                {
+                    deleteBtn.attr( 'data-dismiss', 'modal' ).off('.bs-confirm-delete').on( 'click.bs-confirm-delete', { originalObject: $( this ) }, plugin.settings.delete_callback );
+                    hasCallback = true;
+                }
+                else
+                {
+                    console.log( plugin.settings.delete_callback + ' is not a valid callback' );
+                }
+            }
+            if ( !hasCallback &&  '' !== event.currentTarget.href )
+            {
+                deleteBtn.attr( 'href', event.currentTarget.href );
             }
 
             if ( null !== plugin.settings.cancel_callback )
             {
-                $( '#bootstrap-confirm-dialog-cancel-delete-btn' ).off().on( 'click', { originalObject: $( this ) }, plugin.settings.cancel_callback );
+                cancelBtn.off('.bs-confirm-delete').on( 'click.bs-confirm-delete', { originalObject: $( this ) }, plugin.settings.cancel_callback );
             }
         };
     };
@@ -91,7 +98,7 @@
             var plugin = new bootstrap_confirm_delete( this, options );
 
             element.data( 'bootstrap_confirm_delete', plugin );
-            element.on( 'click', plugin.onDelete );
+            element.off('.bs-confirm-delete').on( 'click.bs-confirm-delete', plugin.onDelete );
 
             return plugin;
         } );


### PR DESCRIPTION
Added sh1ft-at-github change for unbinding. Made binds namespaced, so that they do not interfere with other binds.

Moved delete_callback binding outside of the callback binding, so that it is used even when the callback is not defined. 

Added variables for deleteBtn and cancelBtn (minor optimization).

Adapted the documentation to reflect the actual implementation when it comes to attributes (data_type was in documentation but data-type is used).

Added callback parameters section to documentation.
